### PR TITLE
added support for CentOS; dkms kernel module

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -15,6 +15,7 @@ class afs::client (
   $config_path       = $afs::params::config_path,
   $package_name      = $afs::params::client_package_name,
   $krb5_package_name = $afs::params::krb5_package_name,
+  $dkms_package_name = $afs::params::dkms_package_name,
   $service_name      = $afs::params::client_service_name,
   $service_status    = $afs::params::client_service_status,
 ) inherits afs::params {

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -2,6 +2,7 @@
 class afs::client::install {
   $package_name      = $afs::client::package_name
   $krb5_package_name = $afs::client::krb5_package_name
+  $dkms_package_name = $afs::client::dkms_package_name
 
   package { 'openafs-client':
     ensure => installed,
@@ -11,4 +12,11 @@ class afs::client::install {
   package { $krb5_package_name:
     ensure => installed,
   }
+
+  if undef != $dkms_package_name {
+    package { $dkms_package_name:
+      ensure => installed,
+    }
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,17 @@ class afs::params {
       $client_service_name = 'afs'
       $client_service_status = true
     }
+    'CentOS': {
+      $client_cache_dir = '/var/cache/openafs'
+      $client_cache_size = 'AUTOMATIC'
+      $sysname = ['amd64_linux26']
+      $config_path = '/etc/openafs'
+      $client_package_name = 'openafs-client'
+      $krb5_package_name = 'openafs-krb5'
+      $dkms_package_name = 'dkms-openafs'
+      $client_service_name = 'openafs-client'
+      $client_service_status = true
+    }
     'Ubuntu': {
       $client_cache_dir = '/var/cache/openafs'
       $client_cache_size = $::afs_cache_size


### PR DESCRIPTION
tested with CentOS 7.3. Depends on yumrepo CentOS Storage SIG defined explicitly, and proper ordering set, e.g.:

 class { 'afs::client':
   require => Yumrepo['storage-sig'],
 }